### PR TITLE
Added 'serve' command

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var program = require('commander');
 var fs = require('fs');
-var lib = require('./lib')
+var lib = require('./lib');
 var colors = require('colors');
 var chalk = require('chalk');
 
@@ -30,6 +30,7 @@ program
     .version('0.0.9')
     .option('-t, --theme <theme name>', 'Specify theme for export or publish (modern, traditional, crisp)', 'modern')
     .option('-f, --force', 'Force publish - bypasses schema testing.')
+    .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000);
 
 program
     .command('init')
@@ -82,8 +83,15 @@ program
     });
 
 program
+    .command('serve')
+    .description('Serve resume at http://localhost:4000/')
+    .action(function() {
+        lib.serve(program.port, program.theme);
+    });
+
+program
     .command('register')
-    .description('register an account at https://registry.jsonresume.org')
+    .description('Register an account at https://registry.jsonresume.org')
     .action(function() {
         readFileFunction(function(resumeJson, readFileErrors) {
             lib.register(resumeJson);
@@ -118,13 +126,12 @@ program
 
 program
     .command('settings')
-    .description('settings........')
+    .description('Not yet implemented')
     .action(function() {
         readFileFunction(function() {
             lib.settings(program);
         });
     });
-
 
 program.parse(process.argv);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var test = require('./test');
 var publish = require('./publish');
 var register = require('./register');
 var exportResume = require('./exportResume');
-
+var serve = require('./serve');
 
 module.exports = {
     init: init,
@@ -11,5 +11,5 @@ module.exports = {
     publish: publish,
     register: register,
     exportResume: exportResume,
-
-}
+    serve: serve
+};

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,0 +1,43 @@
+var fs = require('fs');
+var http = require('http');
+var resumeToHtml = require('resume-to-html');
+var Spinner = require('cli-spinner').Spinner;
+
+module.exports = function(port, theme) {
+	var file = './resume.json';
+	if (!fs.existsSync(file)) {
+		console.log(file + ' could not be found');
+		return;
+	}
+	http.createServer(function (req, res) {
+		fs.readFile(file, {encoding: 'utf8'}, function(err, data) {
+			var json;
+			try {
+				json = JSON.parse(data);
+			} catch(err) {
+				var msg = 'Parse error: ' + file;
+				res.writeHead(404);
+				res.end(msg);
+				process.stdout.clearLine();
+				process.stdout.cursorTo(0);
+				console.log(msg);
+				return;
+			}
+			res.writeHead(
+				200,
+				{'Content-Type': 'text/html'}
+			);
+			resumeToHtml(json, {theme: theme}, function(html) {
+				res.end(html);
+			});
+		});
+        }).listen(port);
+	
+	console.log('');
+	console.log('Preview: http://localhost:' + port + '/');
+	console.log('Press ctrl-c to stop')
+	console.log('');
+	
+	var spinner = new Spinner('serving...');
+	spinner.start();
+};


### PR DESCRIPTION
Hey!

I've added the `serve` command. 
It starts a local web server that serves the HTML-version of the resume.

The HTML-version is re-generated every request. This means you can keep the server running while you edit your resume.json and then just refresh your browser to view the result.
#### Example usage:

```
$ resume serve

Preview: http://localhost:4000/
Press ctrl-c to stop

\ serving...
```

Or run it with parameters:

```
$ resume serve --port 80
$ resume serve --port 80 --theme crisp
```
#### Error handling:

`serve` also handles read and/or parse errors gracefully. For example: if you resume.json fails to parse, just fix the error and refresh your browser.
