### PR TITLE
open browser when serve

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ program
     .version('0.0.9')
     .option('-t, --theme <theme name>', 'Specify theme for export or publish (modern, traditional, crisp)', 'modern')
     .option('-f, --force', 'Used by `publish` - bypasses schema testing.')
-    .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000);
+    .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000)
+    .option('-s, --silent', 'Used by `serve` to tell it if open browser auto or not.', false);
 
 lib.version.checkConfigFile(function(message) {
     if (message === 'out of date') {
@@ -92,7 +93,7 @@ lib.version.checkConfigFile(function(message) {
         .command('serve')
         .description('Serve resume at http://localhost:4000/')
         .action(function() {
-            lib.serve(program.port, program.theme);
+            lib.serve(program.port, program.theme, program.silent);
         });
 
     program

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -3,7 +3,7 @@ var http = require('http');
 var resumeToHtml = require('resume-to-html');
 var Spinner = require('cli-spinner').Spinner;
 
-module.exports = function(port, theme) {
+module.exports = function(port, theme, silent) {
 	var file = './resume.json';
 	if (!fs.existsSync(file)) {
 		console.log(file + ' could not be found');
@@ -34,10 +34,15 @@ module.exports = function(port, theme) {
         }).listen(port);
 	
 	console.log('');
-	console.log('Preview: http://localhost:' + port + '/');
+	if(!silent) {
+		console.log('Opening the browser...');
+		open(previewUrl);
+	} else {
+		console.log('Preview: ' + previewUrl);
+	}	
 	console.log('Press ctrl-c to stop')
 	console.log('');
-	
+
 	var spinner = new Spinner('serving...');
 	spinner.start();
 };


### PR DESCRIPTION
About #24.  It's very useful.

And  i added an option to tell `serve` to open the browser or not. **Default is 'yes'!**

**Example:**

```
$ resume serve

Opening the browser...
Press ctrl+c to stop

/ serving....
```

This will open the browser and can preview the HTML-version of the resume.

And if you do not want to open browser defaultly, you can do like this:

```
$ resume serve -s
or
$ resume serve --silent

Preview: http://localhost:4000/
Press ctrl-c to stop

\ serving...
```

Of cause, run it with other params:

```
$ resume serve --port 80 -s
$ resume serve --port 80 --theme crisp -s
```
