### PR TITLE
Get file format from file name during export

### DIFF
--- a/lib/exportResume.js
+++ b/lib/exportResume.js
@@ -7,6 +7,8 @@ var fs = require('fs');
 var read = require('read');
 var spinner = require("char-spinner");
 
+var SUPPORTED_FILE_FORMATS = ["html", "pdf"];
+
 function exportResume(resumeJson, fileName, program, callback) {
     var theme = program.theme;
 
@@ -26,6 +28,10 @@ function exportResume(resumeJson, fileName, program, callback) {
             } else if (fileFormatFound) {
                     fileFormatToUse = fileFormatFound;
                     fileName = fileName.substring(0, fileName.lastIndexOf('.'));
+            }
+
+            if (SUPPORTED_FILE_FORMATS.indexOf(fileFormatToUse) === -1) {
+                fileFormatToUse = null;
             }
 
             formatSelectMenu(fileFormatToUse, function(format) {
@@ -50,6 +56,10 @@ function exportResume(resumeJson, fileName, program, callback) {
         } else if (fileFormatFound) {
                fileFormatToUse = fileFormatFound;
                fileName = fileName.substring(0, fileName.lastIndexOf('.'));
+        }
+
+        if (SUPPORTED_FILE_FORMATS.indexOf(fileFormatToUse) === -1) {
+            fileFormatToUse = null;
         }
 
         formatSelectMenu(fileFormatToUse, function(format) {


### PR DESCRIPTION
During the resume export:
- If a valid file format is included in the file name, use it and don't prompt the user for the format.
- If the file format is not valid, the export process ends, and no file is created.
- If the file name doesn't include the file format, prompt the user for the format
