### PR TITLE
Changes to display error when export HTML format results in some error

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async.waterfall(lib.waterfallArray, function(err, results) {
         .description('Export locally to .html, .md or .pdf. Supply a --format <file format> flag and argument to specify export format.')
         .action(function(fileName) {
             lib.exportResume(results.resumeJson, fileName, program, function(err, fileName, format) {
-                console.log(chalk.green('\nDone! Find your new', format, 'resume at', process.cwd() + '/' + fileName + format));
+                console.log(chalk.green('\nDone! Find your new', format, 'resume at', process.cwd() + '\\' + fileName + format));
             });
         });
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ async.waterfall(lib.waterfallArray, function(err, results) {
 			    if(err) {
 				  console.log(chalk.red(err));
 				} else {
-				  console.log(chalk.green('Done! Find your new', format, 'resume at', process.cwd() + '\\' + fileName + format));
+				  console.log(chalk.green('Done! Find your new', format, 'resume at', process.cwd().split('\\').join('/') + '\\' + fileName + format));
 				}
             });
         });

--- a/index.js
+++ b/index.js
@@ -4,13 +4,11 @@ var pkg = require('./package.json');
 var lib = require('./lib');
 var program = require('commander');
 var async = require('async');
-var colors = require('colors');
 var chalk = require('chalk');
-var read = require('read');
 
 program
     .version(pkg.version)
-    .option('-t, --theme <theme name>', 'Specify theme for export or publish (modern, traditional, crisp)', 'flat')
+    .option('-t, --theme <theme name>', 'Specify theme for serve, export or publish (modern, traditional, crisp)', 'flat')
     .option('-F, --force', 'Used by `publish` - bypasses schema testing.')
     .option('-f, --format <file type extension>', 'Used by `export`.')
     .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000)
@@ -61,7 +59,11 @@ async.waterfall(lib.waterfallArray, function(err, results) {
         .description('Export locally to .html, .md or .pdf. Supply a --format <file format> flag and argument to specify export format.')
         .action(function(fileName) {
             lib.exportResume(results.resumeJson, fileName, program, function(err, fileName, format) {
-                console.log(chalk.green('\nDone! Find your new', format, 'resume at', process.cwd() + '\\' + fileName + format));
+			    if(err) {
+				  console.log(chalk.red(err));
+				} else {
+				  console.log(chalk.green('Done! Find your new', format, 'resume at', process.cwd() + '\\' + fileName + format));
+				}
             });
         });
 

--- a/lib/exportResume.js
+++ b/lib/exportResume.js
@@ -25,9 +25,7 @@ function exportResume(resumeJson, fileName, program, callback) {
 
             formatSelectMenu(fileFormatToUse, function(format) {
                 if (format === '.html') {
-                    sendExportRequest(resumeJson, fileName, theme, format, function() {
-                        callback(null, fileName, format);
-                    });
+                    sendExportRequest(resumeJson, fileName, theme, format, callback);
                 } else if (format === '.pdf') {
                     sendExportPDFRequest(resumeJson, fileName, theme, format, function() {
                         callback(null, fileName, format);
@@ -42,9 +40,7 @@ function exportResume(resumeJson, fileName, program, callback) {
         
         formatSelectMenu(fileFormatToUse, function(format) {
             if (format === '.html') {
-                sendExportRequest(resumeJson, fileName, theme, format, function() {
-                    callback(null, fileName, format);
-                });
+                sendExportRequest(resumeJson, fileName, theme, format, callback);
             } else if (format === '.pdf') {
                 sendExportPDFRequest(resumeJson, fileName, theme, format, function() {
                     callback(null, fileName, format);
@@ -70,9 +66,11 @@ function sendExportRequest(resumeJson, fileName, theme, format, callback) {
             resume: resumeJson
         })
         .set('Accept', 'application/json')
-        .end(function(response) {
-            fs.writeFileSync(process.cwd() + '/' + fileName + format, response.text);
-            callback();
+        .end(function(err, response) {
+		    if(!err) {
+              fs.writeFileSync(process.cwd() + '/' + fileName + format, response.text);
+			}
+            callback(err, fileName, format);
         });
     return;
 }

--- a/lib/exportResume.js
+++ b/lib/exportResume.js
@@ -11,7 +11,6 @@ var SUPPORTED_FILE_FORMATS = ["html", "pdf"];
 
 function exportResume(resumeJson, fileName, program, callback) {
     var theme = program.theme;
-
     if (!fileName) {
         read({
             prompt: "Provide a file name: ",
@@ -66,11 +65,15 @@ function sendExportRequest(resumeJson, fileName, theme, format, callback) {
             resume: resumeJson
         })
         .set('Accept', 'application/json')
-        .end(function(err, response) {
-		    if(!err) {
-              fs.writeFileSync(process.cwd() + '/' + fileName + format, response.text);
+        .end(function(response) {
+		    var errorText = null,
+			    responseText = response.text;
+		    if(responseText && responseText.indexOf('<html>') > -1) {
+              fs.writeFileSync(process.cwd() + '/' + fileName + format, responseText);
+			} else {
+			    errorText = responseText;
 			}
-            callback(err, fileName, format);
+            callback(errorText, fileName, format);
         });
     return;
 }


### PR DESCRIPTION
- export for HTML format uses 
- When incorrect theme name is provided, themeServer returns a statuscode of "200" and a response.text='Theme could not be found in the npm registry.'
- When theme name is correct, response.text contains the HTML to be rendered in the browser

The fix I added is more of a stop gap until the response from themeServer is corrected to return an error code/error message.