### PR TITLE
Display options after command in the help text

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var chalk = require('chalk');
 var read = require('read');
 
 program
+    .usage("[command] [options]")
     .version(pkg.version)
     .option('-t, --theme <theme name>', 'Specify theme for export or publish (modern, traditional, crisp)', 'flat')
     .option('-F, --force', 'Used by `publish` - bypasses schema testing.')


### PR DESCRIPTION
Changes the text when running `resume --help` from `Usage: resume [options] [command]` to `Usage: resume [command] [options]`.

The reason for the PR is that the help text should be more clear on the order you should pass  arguments to the program.