### PR TITLE
Allow serve to use a resume.json file in a different directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ lib.preFlow(function(err, results) {
     .option('-t, --theme <theme name>', 'Specify theme for export or publish (modern, traditional, crisp)', 'flat')
     .option('-F, --force', 'Used by `publish` - bypasses schema testing.')
     .option('-f, --format <file type extension>', 'Used by `export`.')
+    .option('-r, --resume <resume filename>', 'Used by `serve` (default: resume.json)', path.join(process.cwd(), 'resume.json'))
     .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000)
     .option('-s, --silent', 'Used by `serve` to tell it if open browser auto or not.', false);
 
@@ -80,7 +81,7 @@ lib.preFlow(function(err, results) {
     .command('serve')
     .description('Serve resume at http://localhost:4000/')
     .action(function() {
-      lib.serve(program.port, program.theme, program.silent);
+      lib.serve(program.port, program.theme, program.resume, program.silent);
     });
 
   program.parse(process.argv);

--- a/lib/builder/index.js
+++ b/lib/builder/index.js
@@ -28,9 +28,9 @@ function sendExportHTML(resumeJson, theme, callback) {
   return;
 }
 
-module.exports = function resumeBuilder(theme, cb) {
-  var file = path.join(process.cwd(), 'resume.json');
-  fs.readFile(file, function(err, resumeJson) {
+module.exports = function resumeBuilder(theme, resumeFilename, cb) {
+
+  fs.readFile(resumeFilename, function(err, resumeJson) {
     var resumeJson;
     if (err) {
       console.log(chalk.yellow('Could not find:'), file);

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -12,8 +12,8 @@ function serveFile(req, res) {
     }).resume();
 }
 
-function reBuildResume(theme, cb) {
-    builder(theme, function(err, html) {
+function reBuildResume(theme, resumeFilename, cb) {
+    builder(theme, resumeFilename, function(err, html) {
         if(err) {
             process.stdout.clearLine();
             process.stdout.cursorTo(0);
@@ -30,10 +30,10 @@ function reBuildResume(theme, cb) {
     });
 }
 
-module.exports = function(port, theme, silent) {
+module.exports = function(port, theme, resumeFilename, silent) {
     http.createServer(function(req, res) {
         if(req.url === '/' || req.url === '/index.html') {
-            reBuildResume(theme, serveFile.bind(this, req, res));
+            reBuildResume(theme, resumeFilename, serveFile.bind(this, req, res));
         } else {
             serveFile(req, res);
         }


### PR DESCRIPTION
This PR adds a `-r` and `--resume` parameter for the serve command, to allow specifying a different `resume.json` file. This makes it easier to test a theme with your own resume in a different directory. For example I have:

    ~/src/jsonresume-theme-onepage

and:

    ~/src/resume/resume.json

And now I can do this:

    ~/s/jsonresume-theme-onepage ❯❯❯ resume serve -r ~/src/resume/resume.json