### PR TITLE
Set a default for package json

### DIFF
--- a/lib/builder/index.js
+++ b/lib/builder/index.js
@@ -45,8 +45,14 @@ module.exports = function resumeBuilder(theme, cb) {
         return cb(err);
       }
     }
+    
+    var packageJson = {};
 
-    var packageJson = require(path.join(process.cwd(), 'package'));
+    try {
+      packageJson = require(path.join(process.cwd(), 'package'));
+    } catch(e) {
+      // 'package' module does not exist
+    }
 
     var render;
     try {


### PR DESCRIPTION
`resume serve` failed for me with a error about the module 'package' wasn't found in the current directory. 

This patch makes sure to initialize the `packageJson` variable with a empty object so that if the package isn't found we just continue as we would normally instead of failing hard.

:rocket: 