### PR TITLE
adding default public directory and option for choosing it. (default: 'public')

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ lib.preFlow(function(err, results) {
     .option('-F, --force', 'Used by `publish` - bypasses schema testing.')
     .option('-f, --format <file type extension>', 'Used by `export`.')
     .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000)
-    .option('-s, --silent', 'Used by `serve` to tell it if open browser auto or not.', false);
+    .option('-s, --silent', 'Used by `serve` to tell it if open browser auto or not.', false)
+    .option('-d, --dir <path>', 'Used by `serve` to indicate a public directory path.', 'public');
 
   program
     .command('init')
@@ -80,7 +81,7 @@ lib.preFlow(function(err, results) {
     .command('serve')
     .description('Serve resume at http://localhost:4000/')
     .action(function() {
-      lib.serve(program.port, program.theme, program.silent);
+      lib.serve(program.port, program.theme, program.silent, program.dir);
     });
 
   program.parse(process.argv);

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,18 +1,18 @@
 var fs = require('fs');
+var path = require('path');
 var http = require('http');
 var open = require('open');
 var static = require('node-static');
 
 var builder = require('./builder');
-var file = new static.Server(process.cwd(), { cache: 1 });
 
-function serveFile(req, res) {
+function serveFile(file, req, res, dir) {
     req.addListener('end', function () {
         file.serve(req, res);
     }).resume();
 }
 
-function reBuildResume(theme, cb) {
+function reBuildResume(theme, dir, cb) {
     builder(theme, function(err, html) {
         if(err) {
             process.stdout.clearLine();
@@ -21,7 +21,7 @@ function reBuildResume(theme, cb) {
             html = err;
         }
 
-        fs.writeFile(process.cwd() + '/index.html', html, function(err) {
+        fs.writeFile(path.join(process.cwd(), dir, 'index.html'), html, function(err) {
             if(err) {
                 console.log(err);
             }
@@ -30,12 +30,17 @@ function reBuildResume(theme, cb) {
     });
 }
 
-module.exports = function(port, theme, silent) {
+module.exports = function(port, theme, silent, dir) {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
+    var file = new static.Server(path.join(process.cwd(), dir), { cache: 1 });
     http.createServer(function(req, res) {
         if(req.url === '/' || req.url === '/index.html') {
-            reBuildResume(theme, serveFile.bind(this, req, res));
+            reBuildResume(theme, dir, serveFile.bind(this, file, req, res));
         } else {
-            serveFile(req, res);
+            serveFile(file, req, res);
         }
 
     }).listen(port);


### PR DESCRIPTION
Currently, resume-cli utilizes node-static in an ad-hoc way. Because the static server's path is root directory, all other unnecessary sources are exposed to the public. To avoid such exposure, I added public directory as follows:

1. The default public directory is 'public'.
2. A user can choose a public directory with an option ('-d', '--dir').
3. The output path of 'index.html' is moved to the public directory.

