### PR TITLE
remove mention of .md

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ lib.preFlow(function(err, results) {
 
   program
     .command('export [fileName]')
-    .description('Export locally to .html, .md or .pdf. Supply a --format <file format> flag and argument to specify export format.')
+    .description('Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format.')
     .action(function(fileName) {
       lib.exportResume(resumeJson, fileName, program, function(err, fileName, format) {
         console.log(chalk.green('\nDone! Find your new', format, 'resume at:\n', path.resolve(process.cwd(), fileName)));


### PR DESCRIPTION
Markdown doesn't seem to be supported by `export`.  Perhaps it should be removed from the cli description of the command?