### PR TITLE
Improve validation message

### DIFF
--- a/lib/register/validate.js
+++ b/lib/register/validate.js
@@ -4,7 +4,7 @@ module.exports = {
         if (re.test(username)) {
             return;
         }
-        console.log('Username may only contain alphanumeric characters, underscores or dashes and cannot begin with a dash or underscore.'.red);
+        console.log('Username may only contain alphanumeric characters, underscores or dashes, must be at least 3 characters, and cannot begin with a dash or underscore.'.red);
         // must be over 2 characters
         process.exit();
     },


### PR DESCRIPTION
I was trying to register "et" as a username and didn't understand why it wouldn't accept my name. This improves the message to be more clear of the requirements.