### PR TITLE
fixed terminal message so that the proper export path shows up

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ lib.preFlow(function(err, results) {
     .description('Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format.')
     .action(function(fileName) {
       lib.exportResume(resumeJson, fileName, program, function(err, fileName, format) {
-        console.log(chalk.green('\nDone! Find your new', format, 'resume at:\n', path.resolve(process.cwd(), fileName)));
+        console.log(chalk.green('\nDone! Find your new', format, 'resume at:\n', path.resolve(process.cwd(), fileName + format)));
       });
     });
 


### PR DESCRIPTION
The terminal prompt used to show "/Users/astephen/Documents/Personal/resume-cli/test". 

Changed it so it would say "/Users/astephen/Documents/Personal/resume-cli/test.pdf" instead