### PR TITLE
Updated Stanford Cardinals to singular Cardinal

### DIFF
--- a/test/resume.json
+++ b/test/resume.json
@@ -6,7 +6,7 @@
     "email": "test4@test.com",
     "phone": "(912) 555-4321",
     "website": "http://richardhendricks.com",
-    "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinals!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
+    "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinal!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
     "location": {
       "address": "2712 Broadway St",
       "postalCode": "CA 94115",


### PR DESCRIPTION
The Stanford Cardinal is singular, not plural, so I updated "Go Sooners and Cardinals" to "Go Sooners and Cardinal" (I worked at Stanford for five years).

http://news.stanford.edu/news/2010/november/biggame-week-slideshow-111810.html