### PR TITLE
Fix console not clearing when publishing in Windows PowerShell

### DIFF
--- a/lib/publish/menu.js
+++ b/lib/publish/menu.js
@@ -13,6 +13,7 @@ exports.publish = function(callback) {
     fg: 'cyan'
   });
   menu.reset();
+  console.log('\033[2J');
   menu.write('        PUBLISH MENU\n');
   menu.write('------------------------------\n');
   menu.add(customPublish);


### PR DESCRIPTION
I believe this is because terminal-menu's `menu.reset()` does not properly clear the console.

I have not tested this change on Linux, but it shouldn't make any difference.

Before fix:
![resumebroke](https://cloud.githubusercontent.com/assets/572337/24326110/2ac3b934-1175-11e7-90c0-6ad0aea7ba1e.PNG)

After fix:
![resumefixed](https://cloud.githubusercontent.com/assets/572337/24326111/3795299a-1175-11e7-8597-3bc668dc01da.PNG)
