### PR TITLE
Fix exports for PDSs via puppeteer

### DIFF
--- a/lib/export-resume/index.js
+++ b/lib/export-resume/index.js
@@ -7,7 +7,7 @@ var path = require('path');
 var read = require('read');
 var spinner = require("char-spinner");
 var chalk = require('chalk');
-var pdf = require('html-pdf');
+var puppeteer = require('puppeteer');
 
 var SUPPORTED_FILE_FORMATS = ["html", "pdf"];
 
@@ -75,8 +75,17 @@ function renderHtml(resumeJson, theme){
 }
 
 function createPdf(resumeJson, fileName, theme, format, callback) {
+  (async () => {
     var html = renderHtml(resumeJson, theme);
-    pdf.create(html, {format: 'Letter'}).toFile(fileName + format, callback);
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    
+    await page.emulateMedia('screen');
+    await page.goto(`data:text/html,${html}`, { waitUntil: 'networkidle0' });
+    await page.pdf({path: fileName + format, format: 'Letter', printBackground: true});
+
+    await browser.close();
+  })();
 }
 
 function getFileNameAndFormat(fileName, format) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jspdf": "^1.3.2",
     "node-static": "~0.7.7",
     "open": "0.0.5",
+    "puppeteer": "^1.0.0",
     "read": "~1.0.7",
     "resume-schema": "latest",
     "resume-to-html": "latest",


### PR DESCRIPTION
I saw this pull request #256 about changing to Chrome exporting PDFs and @chasebolt recommended using puppeteer so it is independent of an installed Chrome. This is my shot at it (also, this my first pull request and contribution to OSS, so sorry if I screw up).

This doesn't fix all issues with exporting to PDF, some of them are issues with a theme. The default Flat theme is a three page pdf but a single page/print friendly theme(Spartacus-Prime) does look great.

This does keep the same functionality and even speeds up exporting over html-to-pdf. We could extend export args to allow selection of paper size(default is Letter, it was the old default) and add the ability to create an image of the resume using puppeteer.

## Here is html-to-pdf using the Flat theme:
![html-to-pdf-flat](https://user-images.githubusercontent.com/25473080/36289498-77408486-127d-11e8-8475-45150bc6f715.PNG)

## Here is puppeteer using the Flat theme:
![puppeteer-flat](https://user-images.githubusercontent.com/25473080/36289510-8f0ff556-127d-11e8-8b11-193af2b806be.PNG)

## html-to-pdf using a more print friendly Spartacus-Prime theme(the cut off edges are in the PDF):
![html-to-pdf-spartacus-prime](https://user-images.githubusercontent.com/25473080/36289546-b483bfac-127d-11e8-8505-d679cdde9528.PNG)

## puppeteer using Spartacus-Prime theme:
![puppeteer-spartacus-prime](https://user-images.githubusercontent.com/25473080/36289558-c182923c-127d-11e8-9ea1-32d9a58b29a9.PNG)



