### PR TITLE
fix(export): Adjust `createPdf` for the `puppeteer^1.11.0` API.

### DIFF
--- a/lib/export-resume/index.js
+++ b/lib/export-resume/index.js
@@ -102,7 +102,7 @@ const createPdf = (resumeJson, fileName, theme, format, callback) => {
     const page = await browser.newPage();
 
     await page.emulateMedia(themePkg.pdfRenderOptions && themePkg.pdfRenderOptions.mediaType || 'screen');
-    await page.goto(`data:text/html,${html}`, { waitUntil: 'networkidle0' });
+    await page.setContent(html, { waitUntil: 'networkidle0' });
     await page.pdf({
       path: fileName + format,
       format: 'Letter',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jsonresume-theme-modern": "0.0.18",
     "node-static": "~0.7.7",
     "opn": "5.4.0",
-    "puppeteer": "^1.0.0",
+    "puppeteer": "^1.11.0",
     "read": "~1.0.7",
     "resume-schema": "latest",
     "resume-to-html": "latest",


### PR DESCRIPTION
The latest `puppeteer` seems to have broken PDF generation (with the [`page.goto`](https://github.com/GoogleChrome/puppeteer/issues/728#issuecomment-334301491) workaround), at least locally for me both here in `resume-cli` and in [`@randy.tarampi/resume`](https://www.npmjs.com/package/@randy.tarampi/resume) (which offers a similar PDFing functionality through [`@randy.tarampi/printables`](https://www.npmjs.com/package/@randy.tarampi/printables)).

Per https://github.com/GoogleChrome/puppeteer/issues/728 and https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcontenthtml-options.

Also see the related change (including tests) at https://github.com/randytarampi/me/commit/cb4dffb2a3bd9bdc1640e71f259a768f3e6688e7#diff-fbc2dab1d717f6eb0e4d2620c7fa7f03R21.