### PR TITLE
Set content instead of data in URL

### DIFF
--- a/lib/export-resume/index.js
+++ b/lib/export-resume/index.js
@@ -102,7 +102,7 @@ const createPdf = (resumeJson, fileName, theme, format, callback) => {
     const page = await browser.newPage();
 
     await page.emulateMedia(themePkg.pdfRenderOptions && themePkg.pdfRenderOptions.mediaType || 'screen');
-    await page.goto(`data:text/html,${html}`, { waitUntil: 'networkidle0' });
+    await page.setContent(html, { waitUntil: 'networkidle0' });
     await page.pdf({
       path: fileName + format,
       format: 'Letter',


### PR DESCRIPTION
Looks like using data has a limit to how much HTML can be put in.