### PR TITLE
feat: Use locally installed themes before trying themeserver

### DIFF
--- a/lib/builder/index.js
+++ b/lib/builder/index.js
@@ -58,6 +58,9 @@ module.exports = function resumeBuilder(theme, dir, resumeFilename, cb) {
       render = require(path.join(process.cwd(), packageJson.main || 'index')).render;
     } catch(e) {
       // The file does not exist.
+      try {
+        render = require('jsonresume-theme-' + theme).render;
+      } catch(e){}
     }
 
     if(render && typeof render === 'function') {


### PR DESCRIPTION
The themeserver is failing.  This fix allows you to easily install and serve new themes locally.