### PR TITLE
fix resume json validation

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -49,7 +49,7 @@ function errorFormatter(errors) {
 
 function validate(resumeData, callback) {
     console.log('\n  running validation tests on resume.json ... \n');
-    resumeSchema.validate(resumeData, function(report, errs) {
+    resumeSchema.validate(resumeData, function(errs, report) {
         if (errs) {
             // or json parse errors
             var temp = 'Cannot export. There are errors in your resume.json schema format.\n';


### PR DESCRIPTION
resume-schema uses error-first callbacks, as illustrated in their own readme. https://github.com/jsonresume/resume-schema#readme

Additionally, to avoid problems like this in the future, you should absolutely pin your dependency versions in package.json, rather than always pulling latest. Otherwise, dependencies can change their signature and break your library without warning.