### PR TITLE
Fix init

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var read = require('read');
-var resumeJson = require('resume-schema').resumeJson;
+var resumeJson = require('resume-schema').schema.properties; // The resume JSON is in the 'properties' property of the schema in the 'resume-schema' repo.
 var chalk = require('chalk'); // slowly replace colors with chalk
 
 function fillInit() {


### PR DESCRIPTION
This is a temporary fix for #323 . 

Honestly the dependency management for this project needs a bit of work (IMAO), and I'm not exactly sure when or how this error (#323) started occurring, but it seems that at some point it was decided that the initial resume JSON would be generated from the schema in [resume-schema](https://github.com/jsonresume/resume-schema):

```javascript
var resumeJson = require('resume-schema').resumeJson;
```
However `resume-schema.resumeJson` is undefined. Looking through the resume-schema repo it seems that the JSON should be coming from the `properties` property in the [schema.json](https://github.com/jsonresume/resume-schema/blob/v1.0.0/schema.json) file (exported as `schema`) so simply changing the line to 

```javascript
var resumeJson = require('resume-schema').schema.properties;
```
Should fix the issue for now (tested on node 10.16.0).