### PR TITLE
fix(export): fix encoding in createPdf func

### DIFF
--- a/lib/export-resume/index.js
+++ b/lib/export-resume/index.js
@@ -8,6 +8,7 @@ var read = require('read');
 var spinner = require("char-spinner");
 var chalk = require('chalk');
 var puppeteer = require('puppeteer');
+var btoa = require('btoa');
 
 var SUPPORTED_FILE_FORMATS = ["html", "pdf"];
 
@@ -102,7 +103,7 @@ const createPdf = (resumeJson, fileName, theme, format, callback) => {
     const page = await browser.newPage();
 
     await page.emulateMedia(themePkg.pdfRenderOptions && themePkg.pdfRenderOptions.mediaType || 'screen');
-    await page.goto(`data:text/html,${html}`, { waitUntil: 'networkidle0' });
+    await page.goto(`data:text/html;base64,${btoa(unescape(encodeURIComponent(html)))}`, { waitUntil: 'networkidle0' });
     await page.pdf({
       path: fileName + format,
       format: 'Letter',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-cli",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -72,6 +72,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1094,6 +1099,16 @@
         "mustache": "~0.8.2",
         "resume-schema": "^0.0.17",
         "resume-to-markdown": "^0.0.14"
+      },
+      "dependencies": {
+        "resume-schema": {
+          "version": "0.0.17",
+          "resolved": "https://registry.npmjs.org/resume-schema/-/resume-schema-0.0.17.tgz",
+          "integrity": "sha512-jvCvheUg03OxR3WSu24X8he0KLEYjo2qSDkql2ZS+nWP805yK70kihIeyyURlXc8ZLPsO6QCJYD3lhprAZXcHA==",
+          "requires": {
+            "z-schema": "~3.19.0"
+          }
+        }
       }
     },
     "resume-to-markdown": {
@@ -1103,6 +1118,16 @@
       "requires": {
         "mustache": "~0.8.2",
         "resume-schema": "^0.0.17"
+      },
+      "dependencies": {
+        "resume-schema": {
+          "version": "0.0.17",
+          "resolved": "https://registry.npmjs.org/resume-schema/-/resume-schema-0.0.17.tgz",
+          "integrity": "sha512-jvCvheUg03OxR3WSu24X8he0KLEYjo2qSDkql2ZS+nWP805yK70kihIeyyURlXc8ZLPsO6QCJYD3lhprAZXcHA==",
+          "requires": {
+            "z-schema": "~3.19.0"
+          }
+        }
       }
     },
     "resume-to-text": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "preferGlobal": true,
   "dependencies": {
     "async": "^1.5.0",
+    "btoa": "^1.2.1",
     "chalk": "^1.1.1",
     "char-spinner": "^1.0.1",
     "cli-spinner": "^0.2.1",


### PR DESCRIPTION
Exported data is not encoded properly to be read by puppeteer.  Use new
dependency [btoa](https://www.npmjs.com/package/btoa) to polyfill
browser btoa to base64 encode the html content into url-safe format.

Commit also updates module version in package-lock.json.