### PR TITLE
Patch for error format issue

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -37,7 +37,7 @@ function errorFormatter(errors) {
   //     return;
   // }
 
-  errors.errors.forEach(function(error) {
+  errors.forEach(function(error) {
     console.log(
       "    ",
       cross,
@@ -51,7 +51,7 @@ function errorFormatter(errors) {
     );
   });
 
-  console.log(chalk.red("\n  fail  " + errors.errors.length), "\n");
+  console.log(chalk.red("\n  fail  " + errors.length), "\n");
   console.log("Please fix your resume.json file and try again"); //wording? link to docs
 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -64,8 +64,12 @@ function validate(resumeData, callback) {
         "Cannot export. There are errors in your resume.json schema format.\n";
       if (resumeData === undefined) {
         temp += "Try using The JSONLint Validator at: https://jsonlint.com/\n";
-        errs.errors[0].params.type = "unparsable";
-        errs.errors[0].params.expected = "json";
+        errs.forEach(function (error) {
+          error.message += "\n" + temp;
+          error.params[0] = "unparsable";
+          error.params[1] = "json";
+        });
+
       }
       callback(true, {
         message: temp


### PR DESCRIPTION
 #331
Errors are now passed in, but errors passed in are not an object, they are an array with ZSchema objects. This PR changes the test.js code in 2 places to accomodate the new error format. 

Tested by running against a valid resume.json, then adding bad characters to resume.json and running again to ensure that badly formatted JSON still produces the suggestion to use JSON linter.
