### PR TITLE
removed dependency on validate from *-schema. using zschema directly instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "7.10.1"
   - "8"
   - "10"
 sudo: false

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var colors = require('colors');
 var chalk = require('chalk');
 var path = require('path');
 
-lib.preFlow(function(err, results) {
+lib.preFlow(async function(err, results) {
 
   var resumeJson = results.getResume;
   var config = results.getConfig;
@@ -33,10 +33,8 @@ lib.preFlow(function(err, results) {
   program
     .command('test')
     .description('Schema validation test your resume.json')
-    .action(function() {
-      lib.test.validate(resumeJson, function(error, response) {
-        error && console.log(response.message);
-      });
+    .action(async function() {
+      await lib.test(resumeJson);
     });
 
   program
@@ -55,7 +53,7 @@ lib.preFlow(function(err, results) {
       lib.serve(program.port, program.theme, program.silent, program.dir, program.resume);
     });
 
-  program.parse(process.argv);
+  await program.parseAsync(process.argv);
 
   var validCommands = program.commands.map(function(cmd) {
     return cmd._name;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 require('dotenv').load({silent: true});
-var pkg = require(__dirname + '/package.json');
-var lib = require(__dirname + '/lib');
+var pkg = require('./package.json');
+var lib = require('./lib');
 var program = require('commander');
 var colors = require('colors');
 var chalk = require('chalk');

--- a/lib/pre-flow/validate-schema.js
+++ b/lib/pre-flow/validate-schema.js
@@ -1,19 +1,18 @@
 var test = require('../test.js');
 
-module.exports = function validateSchema(callback, results) {
+module.exports = async function validateSchema(callback, results) {
   var options = process.argv.slice(2);
-  if (['export', 'publish'].indexOf(process.argv[2]) !== -1) { // remove serve for the time being
-    if (options.indexOf('-F') === -1 && options.indexOf('--force') === -1) {
-      test.validate(results.getResume, function(error, response) {
-        if (error) {
-          console.log(response.message);
-        }
-        callback(error, results);
-      });
-    } else {
-      callback(null, results);
-    }
-  } else {
+  if (['export', 'publish'].indexOf(process.argv[2]) === -1) { // remove serve for the time being
+    return callback(null, results);
+  }
+  if (options.indexOf('-F') !== -1 || options.indexOf('--force') !== -1) {
+    return callback(null, results);
+  }
+  try {
+    const response = await test(results.getResume)
     callback(null, results);
+  } catch (error) {
+    console.log(error.message);
+    callback(error)
   }
 };

--- a/lib/pre.js
+++ b/lib/pre.js
@@ -4,7 +4,6 @@ var resumeSchema = require('resume-schema');
 var jsonlint = require('jsonlint');
 var checkVersionAndSession = require('./version').checkVersionAndSession;
 var writeNewConfig = require('./version').writeNewConfig;
-var test = require('./test');
 
 module.exports = {
   getConfig: function(callback) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,95 +1,17 @@
-var fs = require("fs");
-var resumeSchema = require("resume-schema");
-var colors = require("colors");
-var chalk = require("chalk"); // slowly replace colors with chalk
+const schema = require("resume-schema/schema.json");
+const promisify = require('util.promisify');
+const ZSchema = require("z-schema");
+const ZSchemaErrors = require("z-schema-errors");
 
-var symbols = {
-  ok: "\u2713",
-  err: "\u2717"
+const reporter = ZSchemaErrors.init();
+const validator = new ZSchema();
+const validate = promisify((obj, ...args) =>
+  validator.validate(obj, schema, ...args)
+);
+module.exports = async (resume) => {
+  try {
+    return await validate(resume);
+  } catch (errors) {
+    throw new Error(reporter.extractMessage({ report: { errors } }));
+  }
 };
-
-// win32 console default output fonts don't support tick/cross
-if (process && process.platform === "win32") {
-  symbols = {
-    ok: "\u221A",
-    err: "\u00D7"
-  };
-}
-
-var tick = chalk.green(symbols.ok);
-var cross = chalk.red(symbols.err);
-
-//converts the schema's returned path output, to JS object selection notation.
-function pathFormatter(path) {
-  var jsonPath = path.split("/");
-  jsonPath.shift();
-  jsonPath = jsonPath.join(".");
-  jsonPath = jsonPath.replace(".[", "[");
-  return jsonPath;
-}
-
-function errorFormatter(errors) {
-  //if json parse errors
-  // if (readFileErrors) {
-  //     console.log('    ', cross + '  ' + chalk.gray(readFileErrors));
-  //     console.log(chalk.red('\n  fail  ' + errors.errors.length), '\n');
-  //     console.log('Visit'.cyan, 'http://jsonlint.com/', 'for details on correct .json fromatting.'.cyan);
-  //     return;
-  // }
-
-  errors.forEach(function(error) {
-    console.log(
-      "    ",
-      cross,
-      chalk.gray(
-        pathFormatter(error.path),
-        "is",
-        error.params.type,
-        ", expected",
-        error.params.expected ? error.params.expected : error.params.format
-      )
-    );
-  });
-
-  console.log(chalk.red("\n  fail  " + errors.length), "\n");
-  console.log("Please fix your resume.json file and try again"); //wording? link to docs
-}
-
-function validate(resumeData, callback) {
-  console.log("\n  running validation tests on resume.json ... \n");
-  resumeSchema.validate(resumeData, function(errs, report) {
-    if (errs) {
-      // or json parse errors
-      var temp =
-        "Cannot export. There are errors in your resume.json schema format.\n";
-      if (resumeData === undefined) {
-        temp += "Try using The JSONLint Validator at: https://jsonlint.com/\n";
-        errs.forEach(function (error) {
-          error.message += "\n" + temp;
-          error.params[0] = "unparsable";
-          error.params[1] = "json";
-        });
-
-      }
-      callback(true, {
-        message: temp
-      });
-      errorFormatter(errs);
-      process.exit(1);
-    } else {
-      console.log("  " + tick + " Passed all validation tests. \n".green);
-      // console.log(report)
-
-      callback(false);
-    }
-  });
-}
-
-module.exports = {
-  validate: validate,
-  errorFormatter: errorFormatter
-};
-
-//TODO error handling for single quotes
-
-// use json error handler to pinpoint errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,6 +222,14 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -273,6 +281,34 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
       "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -381,6 +417,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -436,6 +477,14 @@
         "uglify-js": "~2.3"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -454,6 +503,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "he": {
       "version": "1.1.1",
@@ -515,15 +569,41 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -915,6 +995,36 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1379,6 +1489,44 @@
         }
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1563,6 +1711,17 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "util.promisify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      }
+    },
     "validator": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
@@ -1689,6 +1848,38 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
         "fd-slicer": "~1.0.1"
+      }
+    },
+    "z-schema": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
+      "integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^11.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "optional": true
+        },
+        "validator": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+          "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+        }
+      }
+    },
+    "z-schema-errors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/z-schema-errors/-/z-schema-errors-0.2.1.tgz",
+      "integrity": "sha1-+W0UMmXoZ/bb/e3aqWsSk5rgkkM=",
+      "requires": {
+        "xtend": "^4.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,9 +164,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1093,6 +1093,27 @@
       "integrity": "sha512-CNomhyZSKzrpUqYCFiRRPpfClz78BhgOb+ksGxLy46Yt/xBwnZP/2bLJO60GbAMnI1nxMCtSj+pjBQtILvPs6w==",
       "requires": {
         "z-schema": "~3.19.0"
+      },
+      "dependencies": {
+        "z-schema": {
+          "version": "3.19.1",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
+          "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
+          "requires": {
+            "commander": "^2.7.1",
+            "lodash.get": "^4.0.0",
+            "lodash.isequal": "^4.0.0",
+            "validator": "^9.0.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+              "optional": true
+            }
+          }
+        }
       }
     },
     "resume-to-html": {
@@ -1114,6 +1135,27 @@
           "integrity": "sha512-CNomhyZSKzrpUqYCFiRRPpfClz78BhgOb+ksGxLy46Yt/xBwnZP/2bLJO60GbAMnI1nxMCtSj+pjBQtILvPs6w==",
           "requires": {
             "z-schema": "~3.19.0"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "3.19.1",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
+              "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
+              "requires": {
+                "commander": "^2.7.1",
+                "lodash.get": "^4.0.0",
+                "lodash.isequal": "^4.0.0",
+                "validator": "^9.0.0"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                  "optional": true
+                }
+              }
+            }
           }
         }
       }
@@ -1133,6 +1175,27 @@
           "integrity": "sha512-CNomhyZSKzrpUqYCFiRRPpfClz78BhgOb+ksGxLy46Yt/xBwnZP/2bLJO60GbAMnI1nxMCtSj+pjBQtILvPs6w==",
           "requires": {
             "z-schema": "~3.19.0"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "3.19.1",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
+              "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
+              "requires": {
+                "commander": "^2.7.1",
+                "lodash.get": "^4.0.0",
+                "lodash.isequal": "^4.0.0",
+                "validator": "^9.0.0"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                  "optional": true
+                }
+              }
+            }
           }
         }
       }
@@ -1153,6 +1216,27 @@
           "integrity": "sha512-CNomhyZSKzrpUqYCFiRRPpfClz78BhgOb+ksGxLy46Yt/xBwnZP/2bLJO60GbAMnI1nxMCtSj+pjBQtILvPs6w==",
           "requires": {
             "z-schema": "~3.19.0"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "3.19.1",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
+              "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
+              "requires": {
+                "commander": "^2.7.1",
+                "lodash.get": "^4.0.0",
+                "lodash.isequal": "^4.0.0",
+                "validator": "^9.0.0"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "2.20.3",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                  "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                  "optional": true
+                }
+              }
+            }
           }
         },
         "resume-to-html": {
@@ -1605,17 +1689,6 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
         "fd-slicer": "~1.0.1"
-      }
-    },
-    "z-schema": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
-      "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
-      "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^9.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "char-spinner": "^1.0.1",
     "cli-spinner": "^0.2.1",
     "colors": "^1.1.2",
-    "commander": "^2.9.0",
+    "commander": "^5.0.0",
     "dotenv": "^2.0.0",
     "jsonlint": "^1.6.2",
     "jsonresume-theme-crisp": "^0.2.12",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "resume-to-text": "latest",
     "should": "^11.1.0",
     "superagent": "^3.8.3",
-    "terminal-menu": "^2.1.1"
+    "terminal-menu": "^2.1.1",
+    "util.promisify": "^1.0.1",
+    "z-schema": "^4.2.2",
+    "z-schema-errors": "^0.2.1"
   },
   "devDependencies": {
     "mocha": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.7",
   "description": "The JSON Resume command line interface",
   "main": "index.js",
+  "engines": {
+    "node": ">=7.10.1"
+  },
   "scripts": {
     "test": "node node_modules/mocha/bin/mocha test test/*.js"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,0 @@
-require("dotenv").load();
-var should = require("should");
-
-describe("", function(done) {
-  it("", function(done) {
-    done();
-  });
-});

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const validate = require('../lib/test');
+
+describe("validate", () => {
+  it("should not throw an error for a valid resume object", (done) => {
+    validate({ basics: {} }).then(() => done());
+  });
+  it("should throw an error for an invalid resume object", (done) => {
+    validate({ notInTheSchema: true }).catch(({message}) => {
+      assert.equal(message, `An error occurred 'Additional properties not allowed: notInTheSchema'.`);
+      done();
+    })
+  });
+});


### PR DESCRIPTION
This is re: "move the validator to a separate resume-validator repo" from https://github.com/jsonresume/resume-schema/issues/349 (and specifically https://github.com/jsonresume/resume-schema/issues/349#issuecomment-608274390).

To my knowledge, this project (resume-cli) is the only project that depends on resume-schema, so we should be able to remove the validate export and related code from resume-schema once / if the branch for this PR is merged.