### PR TITLE
fix: only handle '-r' in arg if '-r='

### DIFF
--- a/lib/pre-flow/get-resume.js
+++ b/lib/pre-flow/get-resume.js
@@ -4,7 +4,7 @@ var jsonlint = require('jsonlint');
 module.exports = function getResume(callback) {
   var jsonLocation = './resume.json';
   process.argv.forEach(function(arg) {
-    if(arg.indexOf('--resume') !== -1 || arg.indexOf('-r') !== -1) {
+    if (arg.indexOf('--resume=') !== -1 || arg.indexOf('-r=') !== -1) {
       jsonLocation = arg.replace('--resume=', '').replace('-r=','');
     }
   });


### PR DESCRIPTION
### Description
When trying to use `resume-cli` in a directory that has `-r` in it, `test/build` will fail. This is because one of the args to the Node process is that path, (e.g. `/Users/nickglazer/workspace/nick-glazer-resume/node_modules/.bin/resume`) and it satisfies the conditional and uses that path as the `jsonLocation`. The solution is to check for `-r=` as instead.