### PR TITLE
fix(theme): use normalized theme name by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ lib.preFlow(async function(err, results) {
   program
     .usage("[command] [options]")
     .version(pkg.version)
-    .option('-t, --theme <theme name>', 'Specify theme used by `export` (default: even)', normalizeTheme, 'even')
+    .option('-t, --theme <theme name>', 'Specify theme used by `export` (default: even)', normalizeTheme, 'jsonresume-theme-even')
     .option('-f, --format <file type extension>', 'Used by `export`.')
     .option('-r, --resume <resume filename>', 'Used by `serve` (default: resume.json)', path.join(process.cwd(), 'resume.json'))
     .option('-p, --port <port>', 'Used by `serve` (default: 4000)', 4000)


### PR DESCRIPTION
Commander does not call custom option processor when the respective value is not specified by the user, so we must use the normalized theme name by default.