### PR TITLE
Feature/custom schema for validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ lib.preFlow(async (err, results) => {
     )
     .option(
       '--schema <relativePath>',
-      'Used by `test` to validate against a custom scheme.',
-      'default'
+      'Used by `test` to validate against a custom schema.',
     );
 
   program

--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ lib.preFlow(async (err, results) => {
       '-d, --dir <path>',
       'Used by `serve` to indicate a public directory path.',
       'public',
+    )
+    .option(
+      '--schema <relativePath>',
+      'Used by `test` to validate against a custom scheme.',
+      'default'
     );
 
   program

--- a/lib/test.js
+++ b/lib/test.js
@@ -5,16 +5,20 @@ const ZSchemaErrors = require('z-schema-errors');
 
 const path = require('path');
 const fs = require('fs');
-const getSchema = function() {
-  var index = process.argv.findIndex(value => value === '--schema');         
-  if (index === -1) { return schema; }  // Return the default schema, if a custom schema wasn't specified
-  
-  var path_arg = process.argv[index + 1];
-  var pathToFile = path.join(process.cwd(), path_arg);
-  var customSchema = fs.readFileSync(pathToFile, { encoding: 'utf8' });
-  var customSchemaJSON = JSON.parse(customSchema);
-  return customSchemaJSON;
-}
+const getSchema = function () {
+  const index = process.argv.findIndex((value) => value === '--schema');
+  if (index === -1) {
+    return schema;
+  } // Return the default schema, if a custom schema wasn't specified
+
+  try {
+    const customSchemaPath = path.join(process.cwd(), process.argv[index + 1]);
+    return JSON.parse(fs.readFileSync(customSchemaPath, { encoding: 'utf-8' }));
+  } catch (error) {
+    console.log(error.message);
+    process.exit();
+  }
+};
 
 const reporter = ZSchemaErrors.init();
 const validator = new ZSchema();

--- a/lib/test.js
+++ b/lib/test.js
@@ -3,10 +3,23 @@ const promisify = require('util.promisify');
 const ZSchema = require('z-schema');
 const ZSchemaErrors = require('z-schema-errors');
 
+const path = require('path');
+const fs = require('fs');
+const getSchema = function() {
+  var index = process.argv.findIndex(value => value === '--schema');         
+  if (index === -1) { return schema; }  // Return the default schema, if a custom schema wasn't specified
+  
+  var path_arg = process.argv[index + 1];
+  var pathToFile = path.join(process.cwd(), path_arg);
+  var customSchema = fs.readFileSync(pathToFile, { encoding: 'utf8' });
+  var customSchemaJSON = JSON.parse(customSchema);
+  return customSchemaJSON;
+}
+
 const reporter = ZSchemaErrors.init();
 const validator = new ZSchema();
 const validate = promisify((obj, ...args) =>
-  validator.validate(obj, schema, ...args),
+  validator.validate(obj, getSchema(), ...args),
 );
 module.exports = async (resume) => {
   try {


### PR DESCRIPTION
Shouldn't break anything, since it will still return the default `schema.json` if the arg `--schema` is not specified