### PR TITLE
docs: remove readme content about exporting markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the standard. Tries to identify where any errors may be occurring.
 
 ## `resume export [fileName]`
 
-Exports your resume locally in a stylized HTML, Markdown, or PDF format.
+Exports your resume locally in a stylized HTML or PDF format.
 
 A list of available themes can be found here: http://jsonresume.org/themes/
 


### PR DESCRIPTION
In order to have doc be consistent with available features, the readme should be updated to have "markdown" removed as an export option filetype.

This is a small edit, but it makes it more clear that directly exporting to markdown isn't supported 

- for interest, see also: https://github.com/jsonresume/resume-cli/pull/300
- see also, only supporting HTML and pdf: https://github.com/jsonresume/resume-cli/blob/06e0b81d3e19d08b7d631667e0dc4f5026ad602f/lib/export-resume/index.js#L12-L34

- EDIT I just noticed there's an issue for this here https://github.com/jsonresume/resume-cli/issues/387 This was coincidental timing and me not checking the issue for it, my bad if someone else wanted to do a quick PR for this