### PR TITLE
ci: incorporate dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
In order to have automated dependency updates take place for npm and github actions itself, incorporate a basic dependabot config file (https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml)

note: I realize this PR was unsolicited and doesn't have an associated request issue, but it's an easy PR to put together real quick. It looks like there are other automated dependency PRs such as depshield (https://github.com/jsonresume/resume-cli/issues/381) or greenkeeper (now snyk) (https://github.com/jsonresume/resume-schema/pull/379), however github actions is fairly straightforward and is integrated directly.

feel free to edit, close, etc., thanks for the time 👍 

