### PR TITLE
style(prettier): run inplace formatting writes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,11 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: daily
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: daily

--- a/lib/export-resume/index.js
+++ b/lib/export-resume/index.js
@@ -101,7 +101,7 @@ const createPdf = (resumeJson, fileName, theme, format, callback) => {
     );
     if (themePkg.pdfViewport) {
       await page.setViewport(themePkg.pdfViewport);
-    } 
+    }
     await page.pdf({
       path: fileName + format,
       format: 'Letter',


### PR DESCRIPTION
PRs (e.g. https://github.com/jsonresume/resume-cli/pull/398) are currently failing on prettier being upset about formatting, specifically (https://github.com/jsonresume/resume-cli/pull/398/checks?check_run_id=1267012487):

>
> Run npm run format:check
> 
> > resume-cli@0.0.0-development format:check /home/runner/work/resume-cli/resume-cli
> > prettier --check .
> 
> Checking formatting...
> [warn] .github/dependabot.yml
> [warn] lib/export-resume/index.js
> [warn] Code style issues found in the above file(s). Forgot to run Prettier?
> npm ERR! code ELIFECYCLE
>

but this should square those issues away; just ran `npm run format` to let `prettier` format in-place.