### PR TITLE
ci: have dependabot PRs be prefixed with prefix commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: 'chore(deps)'
+      prefix: 'fix(deps)'
+      prefix-development: 'chore(deps)'
 
   - package-ecosystem: github-actions
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    commit-message:
+      prefix: 'chore(deps)'
 
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
+    commit-message:
+      prefix: 'chore(deps)'


### PR DESCRIPTION
see also: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#commit-message

In order to allow the PR linter to pass commit naming validation ([see here for an example of the lint checking failing](https://github.com/jsonresume/resume-cli/pull/402/checks?check_run_id=1310948384)), update the dependabot configuration file to prefix commits with `chore(deps): xyzabc`, which is based on [this PR](https://github.com/jsonresume/resume-cli/commit/62cf81174d9a11cf5382e9f75023fa1216c98fc8) appearing to use the same style

... It's so close to cooperating, gdangit.