### PR TITLE
fix: use denormalize theme name for server request

### DIFF
--- a/lib/builder/index.js
+++ b/lib/builder/index.js
@@ -5,12 +5,16 @@ const fs = require('fs');
 const request = require('superagent');
 const chalk = require('chalk');
 
+const denormalizeTheme = (value) => {
+  return value.match(/jsonresume-theme-(.*)/)[1];
+};
+
 const sendExportHTML = (resumeJson, theme, callback) => {
   console.log(resumeJson, theme);
   console.log('Requesting theme from server...');
 
   request
-    .post(themeServer + theme)
+    .post(themeServer + denormalizeTheme(theme))
     .send({
       resume: resumeJson,
     })


### PR DESCRIPTION
When using the command `resume server --theme [insert them name]`, the request got back a 400 error with the error message posted down below. 

![image](https://user-images.githubusercontent.com/7350476/98346469-031a6c80-1fe4-11eb-82d2-c19c72e85a5d.png)

The PR creates a denormalizeTheme function in the builder 'index.js' file (mostly for readability) and uses that function to denormalize the theme name from 'jsonresume-theme-even' to 'even'.