### PR TITLE
ci: moved pr workflow into main so we can run the same set of jobs on push and pr. separate workflow for release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,15 @@
-name: Main
-on: push
+name: Lint and Test
+on:
+  - push
+  - pull_request
 
 jobs:
-  test:
+  lint-and-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [10, 12, 14]
-    name: Test on Node.js ${{ matrix.node }}
+    name: Lint and Test on Node.js ${{ matrix.node }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,28 +27,3 @@ jobs:
 
       - name: Test
         run: npm test
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    name: Release
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: 12
-
-      - name: Install
-        run: npm ci
-
-      - name: Run semantic-release
-        uses: cycjimmy/semantic-release-action@v2
-        with:
-          extra_plugins: |
-            conventional-changelog-conventionalcommits
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Pull request
+name: Check Pull Request Title
 on:
   pull_request_target:
     types:
@@ -8,9 +8,9 @@ on:
       - synchronize
 
 jobs:
-  lint:
+  check-pull-reuest-title:
     runs-on: ubuntu-latest
-    name: Lint
+    name: Ensure that PR title can signal semantic release
     steps:
       - name: Check PR title
         uses: amannn/action-semantic-pull-request@v2.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: release
+on:
+  push:
+    branches: [master]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install
+        run: npm ci
+
+      - name: Run semantic-release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The intention here is to gate PRs with tests, and run semantic release when a new release is drafted.

I've tested a bit with [act](https://github.com/nektos/act), but we'll need to merge to master in order to really test this.