### PR TITLE
feat: remove "browsersync: connected" banner

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -38,6 +38,7 @@ module.exports = function ({ port, theme, silent, dir, resumeFilename }) {
       port: port,
       open: !silent && 'local',
       ui: false,
+      notify: false,
     });
   });
 


### PR DESCRIPTION
Cf https://browsersync.io/docs/options#option-notify, this banner doesn't bring much value and when you use chrome native PDF export (my theme isn't working great with `resume export`), this banner gets exported too (to avoid that you have to add a delay before exporting, which is not ideal IMHO).