### PR TITLE
fix: fix logic for resolving path to themes

### DIFF
--- a/lib/render-html.js
+++ b/lib/render-html.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const tryResolve = (...args) => {
   try {
     return require.resolve(...args);
@@ -8,25 +10,24 @@ const tryResolve = (...args) => {
 
 export default async ({ resume, themePath }) => {
   const cwd = process.cwd();
-  let path;
+  let resolvedPath;
   if (themePath[0] === '.') {
-    path = tryResolve(path.join(cwd, themePath), { paths: [cwd] });
-    throw new Error(
-      `Theme ${themePath} could not be resolved relative to ${cwd}`,
-    );
+    resolvedPath = tryResolve(path.join(cwd, themePath), { paths: [cwd] });
   }
-  if (!path) {
-    path = tryResolve(themePath, { paths: [cwd] });
+  if (!resolvedPath) {
+    resolvedPath = tryResolve(themePath, { paths: [cwd] });
   }
-  if (!path && /^[a-z0-9]/i.test(path)) {
-    path = tryResolve(`jsonresume-theme-${themePath}`, { paths: [cwd] });
+  if (!resolvedPath && /^[a-z0-9]/i.test(resolvedPath)) {
+    resolvedPath = tryResolve(`jsonresume-theme-${themePath}`, {
+      paths: [cwd]
+    });
   }
-  if (!path) {
+  if (!resolvedPath) {
     throw new Error(
       `theme path ${themePath} could not be resolved from current working directory`,
     );
   }
-  const theme = require(path);
+  const theme = require(resolvedPath);
   if (typeof theme?.render !== 'function') {
     throw new Error('theme.render is not a function');
   }


### PR DESCRIPTION
I was getting errors when specifying a path to a theme that begins with a dot because `path.join` wasn't a function. I renamed the existing `path` var to `resolvedPath` and imported the path module that `path.join` comes from.