### PR TITLE
fix: improve font rendering with puppeteer

### DIFF
--- a/lib/export-resume.js
+++ b/lib/export-resume.js
@@ -77,7 +77,7 @@ async function createHtml(resumeJson, fileName, themePath, format, callback) {
 const createPdf = (resumeJson, fileName, theme, format, callback) => {
   (async () => {
     const themePkg = getThemePkg(theme);
-    const puppeteerLaunchArgs = [];
+    const puppeteerLaunchArgs = ['--font-render-hinting=none'];
 
     if (process.env.RESUME_PUPPETEER_NO_SANDBOX) {
       puppeteerLaunchArgs.push('--no-sandbox');


### PR DESCRIPTION
I noticed that WOFF2 fonts in a theme look really bad when rendered with puppeteer. The spacing between letters is all messed up. Example:

![1620846841](https://user-images.githubusercontent.com/1049204/118031912-abf7aa80-b32c-11eb-8059-a65e8493c648.png)

This [blog](https://docs.browserless.io/blog/2020/09/30/puppeteer-print.html) recommended setting `--font-render-hinting=none` and that seemed to fix the issue.

Now it looks correct:

![1620846798](https://user-images.githubusercontent.com/1049204/118032078-d9dcef00-b32c-11eb-8cf5-0525745c7bb0.png)
