### PR TITLE
fix: renderHtml not a function bug

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,7 +3,7 @@ const themeServer =
 const fs = require('fs');
 const request = require('superagent');
 const chalk = require('chalk');
-const renderHtml = require('./render-html');
+const renderHtml = require('./render-html').default;
 
 const denormalizeTheme = (value) => {
   return value.match(/jsonresume-theme-(.*)/)[1];


### PR DESCRIPTION
When trying to run `resume serve -t <theme>` with any locally installed theme, the serve command fails with this error: 

```
TypeError: renderHtml is not a function
...
Could not run the render function from local theme.
```

Fix is simple and adds `.default` to `renderHtml` import.