### PR TITLE
docs(README.md): added example Dockerfile and instructions to run inside docker

### DIFF
--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+FROM debian:buster as base0
+RUN apt update -y
+RUN apt upgrade -y
+RUN apt install chromium -y
+RUN apt install npm -y
+RUN npm update -g
+
+FROM base0 as base
+# Ugly workaround for M1 ARM64
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+ENV RESUME_PUPPETEER_NO_SANDBOX=1
+RUN npm install -g resume-cli --unsafe-perm=true --allow-root
+RUN ln /usr/bin/chromium /usr/bin/chromium-browser
+
+# Generate an initial resume.json
+FROM base as init-base
+WORKDIR /resume-init
+RUN yes | resume init 
+
+FROM scratch as init 
+COPY --from=init-base /resume-init/resume.json resume.json
+
+
+
+# Copy resume.json and build a pdf
+FROM base as build-base
+WORKDIR /resume 
+COPY ./resume.json .
+ARG THEME
+RUN npm install jsonresume-theme-${THEME}
+# The only way it actually works
+RUN npm install -g jsonresume-theme-${THEME}
+RUN resume export --theme ${THEME} resume.pdf 
+
+FROM scratch as build-pdf
+COPY --from=build-base /resume/resume.pdf resume.pdf 
+
+
+
+# Serve as html
+FROM base as serve
+WORKDIR /resume 
+COPY ./resume.json .
+ARG THEME
+ENV RESUME_THEME=${THEME}
+RUN npm install jsonresume-theme-${RESUME_THEME}
+# The only way it actually works (not sure why)
+RUN npm install -g jsonresume-theme-${RESUME_THEME}
+CMD resume serve --theme ${RESUME_THEME}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,38 @@ to test the cli, run the dev script:
 npm run dev -- [cli arguments can be passed after the double-dash]
 ```
 
+# Running inside Docker
+
+The basic Dockerfile for the cli is presented in `Dockerfile.example`.  It uses docker [`multistage builds`](https://docs.docker.com/develop/develop-images/multistage-build/). It can be renamed to `Dockerfile` or copied to another directory.
+
+### Creating a sample `resume.json`
+
+This command will copy `resume.json` to a folder called `build`
+
+```
+docker build --target init -o build  .
+```
+
+### Building to pdf
+
+This command will copy the local `resume.json` to the container, build it and then copy `resume.pdf` to a folder called `build`
+
+```
+docker build --target build-pdf --build-arg THEME=<your theme name> -o build .
+```
+
+### Running as a server
+
+This command will start a `nodejs` server at `localhost:4000`
+
+```
+	docker build --target serve --build-arg THEME=<your theme name> resume-server .
+	docker run --rm -p 4000:4000 -it resume-server
+```
+
+Theme names are specified like `paper` or `elegant`, as long as their npm package prefix is `jsonresume-theme`
+
+
 # License
 
 Available under [the MIT license](http://mths.be/mit).


### PR DESCRIPTION
I submitted the first draft of running the library though docker, although I'm not sure if it's the right way. Technically, the library is not dockerized and it's just a container that installs the library through `npm`.

Probably a better solution would be to dockerize the library itself and provide the image on docker hub, such that different commands can be ran. With that being said, I can't say that I'm experienced in dockerizing npm packages