### PR TITLE
docs: adds default theme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Install the command-line tool:
 npm install -g resume-cli
 ```
 
+Optional. You may wish to install the default theme [`jsonresume-theme-even`](https://github.com/rbardini/jsonresume-theme-even).
+
+```
+npm install jsonresume-theme-even
+```
+
 ## Commands at a glance
 
 | command                | description                               |


### PR DESCRIPTION
As I was walking through the CLI installation and trying to export the default `resume.json` created, I ran into this error:

```
➜  ~ resume export myresume.html
/root/.asdf/installs/nodejs/16.10.0/.npm/lib/node_modules/resume-cli/build/render-html.js:46
    throw new Error(`theme path ${themePath} could not be resolved from current working directory`);
          ^

Error: theme path jsonresume-theme-even could not be resolved from current working directory
    at _default (/root/.asdf/installs/nodejs/16.10.0/.npm/lib/node_modules/resume-cli/build/render-html.js:46:11)
    at createHtml (/root/.asdf/installs/nodejs/16.10.0/.npm/lib/node_modules/resume-cli/build/export-resume.js:84:46)
    at module.exports (/root/.asdf/installs/nodejs/16.10.0/.npm/lib/node_modules/resume-cli/build/export-resume.js:36:5)
    at Command.<anonymous> (/root/.asdf/installs/nodejs/16.10.0/.npm/lib/node_modules/resume-cli/build/main.js:67:5)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 0)
    at async /root/.asdf/installs/nodejs/16.10.0/.npm/lib/node_modules/resume-cli/build/main.js:79:3
```

Adding in these instructions will hopefully help guide others through a seamless installation process.