### PR TITLE
fix: export pdf get package theme from local context

### DIFF
--- a/lib/export-resume.js
+++ b/lib/export-resume.js
@@ -49,7 +49,9 @@ const extractFileFormat = (fileName) => {
 };
 const getThemePkg = (theme) => {
   if (theme[0] === '.') {
-    theme = path.join(process.cwd(), theme, 'index.js');
+    theme = path.join(process.cwd(), 'index.js');
+  } else {
+    theme = path.join(process.cwd(), 'node_modules', theme, 'index.js');
   }
   try {
     const themePkg = require(theme);


### PR DESCRIPTION
As discussed in #408 this fix will calculate the theme package from the local context instead the global one. 
This will align the calculation of the theme package path, although in the future it will be interesting to unify every theme package access. 
With these changes it will be possible to use:

``` bash
npm install jsonresume-theme-my-theme
resume export resume.pdf --format pdf --theme my-theme
resume export resume.html --format html --theme my-theme
```