### PR TITLE
fix: support themes exporting ESM modules

### DIFF
--- a/lib/export-resume.js
+++ b/lib/export-resume.js
@@ -1,6 +1,7 @@
 import renderHTML from './render-html';
 import { promisify } from 'util';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 const writeFile = promisify(fs.writeFile);
 const path = require('path');
@@ -47,14 +48,14 @@ const extractFileFormat = (fileName) => {
   }
   return fileName.substring(dotPos + 1).toLowerCase();
 };
-const getThemePkg = (theme) => {
+const getThemePkg = async (theme) => {
   if (theme[0] === '.') {
     theme = path.join(process.cwd(), 'index.js');
   } else {
     theme = path.join(process.cwd(), 'node_modules', theme, 'index.js');
   }
   try {
-    const themePkg = require(theme);
+    const themePkg = await import(pathToFileURL(theme));
     return themePkg;
   } catch (err) {
     // Theme not installed
@@ -78,7 +79,7 @@ async function createHtml(resumeJson, fileName, themePath, format, callback) {
 }
 const createPdf = (resumeJson, fileName, theme, format, callback) => {
   (async () => {
-    const themePkg = getThemePkg(theme);
+    const themePkg = await getThemePkg(theme);
     const puppeteerLaunchArgs = [];
 
     if (process.env.RESUME_PUPPETEER_NO_SANDBOX) {

--- a/lib/render-html.js
+++ b/lib/render-html.js
@@ -28,7 +28,7 @@ export default async ({ resume, themePath }) => {
       `theme path ${themePath} could not be resolved from current working directory`,
     );
   }
-  const theme = require(path);
+  const theme = await import(path);
   if (typeof theme?.render !== 'function') {
     throw new Error('theme.render is not a function');
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The JSON Resume command line interface",
   "main": "index.js",
   "engines": {
-    "node": ">=10.18.1"
+    "node": ">=12.20.0"
   },
   "files": [
     "build/*",


### PR DESCRIPTION
Hey! :wave:

This PR allows supporting custom themes exporting ESM modules.
Currently, we `require` the theme, so it throws this kind of error:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/divlo/Documents/Divlo/jsonresume-theme-custom/index.js from /home/divlo/Documents/Divlo/node_modules/resume-cli/build/render-html.js not supported.
```

This PR fixes this, thanks to using [Dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports).

**Note:** This is a **BREAKING CHANGE** because we need to use Node.js >= v12.20.0 to support dynamic imports, which should not be too dramatic as Node.js v10 is End Of Life.