### PR TITLE
feat(export): allow setting paper size in pdf export

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Please npm install the theme you wish to use locally before attempting to export
 Options:
 
 - `--format <file type>` Example: `--format pdf`
+- `--papersize <paper size>` Example: `--papersize a4`
 - `--theme <name>` Example: `--theme even`
 
 ## `resume serve`

--- a/lib/export-resume.js
+++ b/lib/export-resume.js
@@ -8,7 +8,7 @@ const puppeteer = require('puppeteer');
 const btoa = require('btoa');
 
 module.exports = (
-  { resume: resumeJson, fileName, theme, format },
+  { resume: resumeJson, fileName, theme, format, papersize },
   callback,
 ) => {
   if (!fileName) {
@@ -28,7 +28,7 @@ module.exports = (
       callback(error, fileName, formatToUse);
     });
   } else if (formatToUse === '.pdf') {
-    createPdf(resumeJson, fileName, theme, formatToUse, (error) => {
+    createPdf(resumeJson, fileName, theme, formatToUse, papersize, (error) => {
       if (error) {
         console.error(error, '`createPdf` errored out');
       }
@@ -76,7 +76,14 @@ async function createHtml(resumeJson, fileName, themePath, format, callback) {
     stream.close(callback);
   });
 }
-const createPdf = (resumeJson, fileName, theme, format, callback) => {
+const createPdf = (
+  resumeJson,
+  fileName,
+  theme,
+  format,
+  papersize,
+  callback,
+) => {
   (async () => {
     const themePkg = getThemePkg(theme);
     const puppeteerLaunchArgs = [];
@@ -107,7 +114,7 @@ const createPdf = (resumeJson, fileName, theme, format, callback) => {
     }
     await page.pdf({
       path: fileName + format,
-      format: 'Letter',
+      format: papersize,
       printBackground: true,
       ...themePkg.pdfRenderOptions,
     });

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,6 +41,7 @@ const normalizeTheme = (value, defaultValue) => {
       'jsonresume-theme-even',
     )
     .option('-f, --format <file type extension>', 'Used by `export`.')
+    .option('--papersize <papersize>', 'Used by `export`.', 'Letter')
     .option(
       '-r, --resume <resume filename>',
       "path to the resume in json format. Use '-' to read from stdin",
@@ -89,8 +90,10 @@ const normalizeTheme = (value, defaultValue) => {
   program
     .command('export [fileName]')
     .description(
-      'Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format.',
+      'Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format. ' +
+        'Supply --papersize flag and argument to specify export page format when rendering a PDF.',
     )
+    .option('--papersize <papersize>', 'Paper size to use with PDF', 'Letter')
     .action(async (fileName) => {
       const resume = await getResume({ path: program.resume });
       exportResume(


### PR DESCRIPTION
Hello,

for non-US fellas using Letter as paper format is pretty uncommon. Thus I thought it would be great if you could pass the PDF paper size as an option.

Please let me know about anything improvable, Javascript is not my main programming language.

Cheers!