### PR TITLE
ci: pin version of conventional-changelog-conventionalcommits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v2
         with:
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We're currently unable to make releases as our pipeline uses the latest version of `conventional-changelog-conventionalcommits`, but the latest release has changed.

For an immediate fix, let's pin it to the last version we know it works with.
(Based on the last release taking place in October 2022.)

Later, I can upgrade both `cycjimmy/semantic-release-action` and `conventional-changelog-conventionalcommits` to the latest versions that support each other.