### PR TITLE
ci: update actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - name: Run semantic-release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
-            conventional-changelog-conventionalcommits@5.0.0
+            conventional-changelog-conventionalcommits@7.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes releases by updating and pinning the versions of `cycjimmy/semantic-release-action` and `conventional-changelog-conventionalcommits`.